### PR TITLE
Moved log statement to correct scope to avoid variable scoping errors, ingest_hydrator

### DIFF
--- a/ingest_graph_validator/hydrators/ingest_hydrator.py
+++ b/ingest_graph_validator/hydrators/ingest_hydrator.py
@@ -120,10 +120,9 @@ class IngestHydrator(Hydrator):
                             if relationship_name == 'DERIVED_BY_PROCESSES':
                                 edges.append(Relationship(end_node, 'DUMMY_EXPERIMENTAL_DESIGN', start_node))
 
+                            self._logger.debug(f"({start_node['id']})-[:{relationship_name}]->({end_node['id']})")
                         except KeyError:
-                            self._logger.debug(f"Missing end node at a [{start_node['label']}] entity.")
-
-                        self._logger.debug(f"({start_node['id']})-[:{relationship_name}]->({end_node['id']})")
+                            self._logger.debug(f"Missing end node at a [{start_node['id']}] entity.")
 
         self._logger.info(f"imported {len(edges)} edges")
 


### PR DESCRIPTION
Related to issue https://github.com/ebi-ait/hca-ebi-dev-team/issues/375

The log statement was out of the try scope and would therefore throw errors whenever  `end_node` could not be initialized. Moving the statement to scope should fix the error:

```
line 126, in get_edges
    self._logger.debug(f"({start_node['id']})-[:{relationship_name}]->({end_node['id']})")
UnboundLocalError: local variable 'end_node' referenced before assignment

```

and show the appropriate log from the `except` clause
