### PR TITLE
Fixed sequence_file to cell_suspensions test

### DIFF
--- a/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
+++ b/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
@@ -13,7 +13,7 @@ This next query provides the filenames, biomaterial IDs and nucleic acid sources
 ----
 MATCH path = (b:biomaterial)-[:INPUT_TO_PROCESSES]->(p:process)<-[:DERIVED_BY_PROCESSES]-(f:sequence_file), seq_path = (p)-[:PROTOCOLS]-(l:library_preparation_protocol)
 WHERE NOT b:cell_suspension
-AND l.nucleic_acid_source="single cell"
+AND l.nucleic_acid_source STARTS WITH "single"
 RETURN f.`file_core.file_name`, b.`biomaterial_core.biomaterial_id`, l.nucleic_acid_source
 ----
 

--- a/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
+++ b/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
@@ -14,7 +14,7 @@ This next query provides the filenames, biomaterial IDs and nucleic acid sources
 MATCH path = (b:biomaterial)-[:INPUT_TO_PROCESSES]->(p:process)<-[:DERIVED_BY_PROCESSES]-(f:sequence_file), seq_path = (p)-[:PROTOCOLS]-(l:library_preparation_protocol)
 WHERE NOT b:cell_suspension
 AND l.nucleic_acid_source="single cell"
-RETURN f.file_core.file_name, b.biomaterial_core.biomaterial_id, l.nucleic_acid_source
+RETURN f.`file_core.file_name`, b.`biomaterial_core.biomaterial_id`, l.nucleic_acid_source
 ----
 
 

--- a/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
+++ b/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
@@ -1,24 +1,20 @@
 
-## Test: Sequence files link to cell suspension
+## Test: Sequence files link to cell suspension in single cell experiments
 
 #### Test description
 
-The biomaterial linked to the process linked to a sequence file must be a cell suspension.
+The biomaterial linked to the process linked to a sequence file must be a cell suspension in single cell experiments.
 
-This next query should provide all the subgraphs in the form (file)-(process)-(biomaterial).
+This next query provides the filenames, biomaterial IDs and nucleic acid sources linked together that break this assumption
 
-----
-MATCH path = (b:biomaterial)-[:INPUT_TO_PROCESSES]->(p:process)<-[:DERIVED_BY_PROCESSES]-(f:file)
-WHERE b:cell_suspension
-RETURN path
-----
 
 #### The test
 [source,cypher]
 ----
-MATCH (b:biomaterial)-[:INPUT_TO_PROCESSES]->(p:process)<-[:DERIVED_BY_PROCESSES]-(f:file)
+MATCH path = (b:biomaterial)-[:INPUT_TO_PROCESSES]->(p:process)<-[:DERIVED_BY_PROCESSES]-(f:sequence_file), seq_path = (p)-[:PROTOCOLS]-(l:library_preparation_protocol)
 WHERE NOT b:cell_suspension
-RETURN f.`file_core.file_name`, b.`biomaterial_core.biomaterial_id`
+AND l.nucleic_acid_source="single cell"
+RETURN f.file_core.file_name, b.biomaterial_core.biomaterial_id, l.nucleic_acid_source
 ----
 
 


### PR DESCRIPTION
Related to #8 

Now only checks for not-cell suspension --> sequence file when:

- Nucleic acid source is "single cell"
- File is a sequence file