### PR TITLE
Fixed analysis file picking, improved return

### DIFF
--- a/graph_test_set/paired_end_2_files.adoc
+++ b/graph_test_set/paired_end_2_files.adoc
@@ -1,19 +1,19 @@
-## Test: Paired end experiment has less than 2 files
+## Test: Paired end experiment has 2 or more files
 
 #### Test description
 
-When a sequencing protocol is paired-end, test whether it has 2 or more files linked.
+When a sequencing protocol is paired-end, test whether it has 2 or more sequencing files linked.
 
 
 
 #### The test
 [source,cypher]
 ----
-MATCH (s:sequencing_protocol)<-[:PROTOCOLS]-(p:process)<-[d]-(f:file)
+MATCH (s:sequencing_protocol)<-[:PROTOCOLS]-(p:process)<-[d]-(f:sequence_file)
 WITH s, p, COUNT(d) as num_files
 WHERE s.`paired_end` = false
 AND NOT num_files >= 2
-RETURN num_files
+RETURN num_files, s.`protocol_core.protocol_id`
 ----
 
 

--- a/graph_test_set/paired_end_2_files.adoc
+++ b/graph_test_set/paired_end_2_files.adoc
@@ -10,10 +10,10 @@ When a sequencing protocol is paired-end, test whether it has 2 or more sequenci
 [source,cypher]
 ----
 MATCH (s:sequencing_protocol)<-[:PROTOCOLS]-(p:process)<-[d]-(f:sequence_file)
-WITH s, p, COUNT(d) as num_files
+WITH s, p, f, COUNT(d) as num_files
 WHERE s.`paired_end` = false
 AND NOT num_files >= 2
-RETURN num_files, s.`protocol_core.protocol_id`
+RETURN num_files, f.`file_core.file_name`
 ----
 
 


### PR DESCRIPTION
For `paired_end_2_files.adoc`:
- Only picks analysis files now
- Now returns the filename of the orphaned/misconnected files