### PR TITLE
Error messaging in ingest

### DIFF
--- a/ingest_graph_validator/actions/test_action.py
+++ b/ingest_graph_validator/actions/test_action.py
@@ -92,6 +92,5 @@ class TestAction:
 
             if self._submission_uuid:
                 self._logger.info("Reverting submission graphValidationState to Pending")
-                self._ingest_api.put(f'{submission_url}/graphValidEvent', data=None)
                 self._ingest_api.put(f'{submission_url}/graphPendingEvent', data=None)
 


### PR DESCRIPTION
dcp-504

- Sends the failed test names to ingest
  - This will only show the test names that have failed for now. Better messaging will be done in dcp-508
- Wraps the testing in a try/except that will roll the `graphValidationState` back to `Pending` if something goes wrong