### PR TITLE
Make try catches safer

### DIFF
--- a/ingest_graph_validator/actions/ingest_validator_action.py
+++ b/ingest_graph_validator/actions/ingest_validator_action.py
@@ -93,6 +93,8 @@ class ValidationListener(ConsumerMixin):
             self._logger.info("Reverting submission graphValidationState to Pending")
             self._ingest_api.put(f'{submission_url}/graphPendingEvent', data=None)
 
+        self._graph.delete_all()
+
     def handle_message(self, message):
         try:
             payload = json.loads(message.payload)
@@ -105,7 +107,6 @@ class ValidationListener(ConsumerMixin):
 
             submission = self._ingest_api.get_submission_by_uuid(sub_uuid)
             self.__attempt_validation(submission, sub_uuid)
-            self._graph.delete_all()
         except Exception as e:
             self._logger.error(f"Failed handling with error {e}.")
 


### PR DESCRIPTION
Wraps everything in try/catch to pickup any errors and log them. Ensures messages are always acked and we don't get in an infinite loop of errors if one submission causes an error.

The above happened when a validation was requested and then the submission was deleted **before** the validation took place.