### PR TITLE
Updated sequence_file_linkto_cell_suspesion.adoc

### DIFF
--- a/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
+++ b/graph_test_set/sequence_file_linkto_cell_suspesion.adoc
@@ -13,6 +13,7 @@ This next query provides the filenames, biomaterial IDs and nucleic acid sources
 ----
 MATCH path = (b:biomaterial)-[:INPUT_TO_PROCESSES]->(p:process)<-[:DERIVED_BY_PROCESSES]-(f:sequence_file), seq_path = (p)-[:PROTOCOLS]-(l:library_preparation_protocol)
 WHERE NOT b:cell_suspension
+AND NOT b:imaged_specimen
 AND l.nucleic_acid_source STARTS WITH "single"
 RETURN f, "File should be linked to a cell suspension", labels(f)
 ----


### PR DESCRIPTION
Added 'AND NOT b:imaged_specimen'
This makes it so that if the sequence file is linked to an imaged_specimen, it does not trigger this test failing. See https://app.zenhub.com/workspaces/operations-5fa2d8f2df78bb000f7fb2b5/issues/ebi-ait/hca-ebi-wrangler-central/626