### PR TITLE
dcp-925 large dataset crashes graph validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ The Graph Validator Suite requires docker running in the host machine.
 ```
 git clone git@github.com:ebi-ait/ingest-graph-validator.git
 cd ingest-graph-validator
+python -mvenv .venv
+source .venv/bin/activate
 pip install -e .
 ```
 
@@ -53,7 +55,10 @@ Where ENV could be one of the following values:
    2. `staging` for the staging environment
    3. `prod` for the production environment
 
-3. `docker run -p7687:7687 -p7474:7474 --env NEO4J_AUTH=neo4j/password --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:3.5.14-enterprise` (in another terminal session or with `-d` (detached) flag)
+3. run neo4j locally (in another terminal session or with `-d` (detached) flag)
+```bash
+docker run -p7687:7687 -p7474:7474 --env NEO4J_AUTH=neo4j/password --env=NEO4J_ACCEPT_LICENSE_AGREEMENT=yes neo4j:3.5.14-enterprise
+```
 
 4. `export INGEST_GRAPH_VALIDATOR_INGEST_API_URL=https://api.ingest.archive.data.humancellatlas.org/`
     - If you wish to run the graph validator against a different environment, you can specify the URL to that here (e.g. `http://localhost:8080`)

--- a/ingest_graph_validator/actions/ingest_validator_action.py
+++ b/ingest_graph_validator/actions/ingest_validator_action.py
@@ -7,9 +7,9 @@ import logging
 import time
 
 import requests.exceptions
-from ingest.api.ingestapi import IngestApi
-from ingest.utils.s2s_token_client import S2STokenClient, ServiceCredential
-from ingest.utils.token_manager import TokenManager
+from hca_ingest.api.ingestapi import IngestApi
+from hca_ingest.utils.s2s_token_client import S2STokenClient, ServiceCredential
+from hca_ingest.utils.token_manager import TokenManager
 from kombu import Connection, Exchange, Queue
 from kombu.mixins import ConsumerMixin
 

--- a/ingest_graph_validator/actions/test_action.py
+++ b/ingest_graph_validator/actions/test_action.py
@@ -4,12 +4,15 @@
 
 import logging
 
+from py2neo import Graph
+
 from .common import load_test_queries
 from ..config import Config
 
+
 class TestAction:
 
-    def __init__(self, graph, test_path, exit_on_failure):
+    def __init__(self, graph:Graph, test_path, exit_on_failure):
         self._graph = graph
         self._test_path = test_path
         self._exit_on_failure = exit_on_failure
@@ -63,7 +66,7 @@ class TestAction:
                     self._logger.info("execution terminated")
                     exit(1)
 
-        
+
         self._logger.info("All tests finished")
 
         return {

--- a/ingest_graph_validator/config.py
+++ b/ingest_graph_validator/config.py
@@ -12,18 +12,21 @@ Defaults = {
     'NEO4J_DB_USERNAME': "neo4j",
     'NEO4J_DB_PASSWORD': "password",
     'INGEST_API': "https://api.ingest.archive.data.humancellatlas.org",
+    'INGEST_THROTTLE_PERIOD': 0.3,
     'GOOGLE_APPLICATION_CREDENTIALS': os.path.join(os.path.expanduser("~"), ".secrets", "gcp_credentials"),
     'INGEST_JWT_AUDIENCE': "https://data.humancellatlas.org/",
     'AMQP_CONNECTION': "amqp://guest:guest@localhost:5672",
     'AMQP_EXCHANGE_NAME': "ingest.validation.exchange",
     'AMQP_QUEUE_NAME': "ingest.validation.graph.queue",
     'AMQP_ROUTING_KEY': "ingest.validation.graph.queue",
+    'NEO4J_IMPORT_BATCH_SIZE': 1000,
 }
 
 
 Config = {
     'LOG_LEVEL': os.environ.get("INGEST_GRAPH_VALIDATOR_LOG_LEVEL", "ERROR"),
     'INGEST_API': os.environ.get("INGEST_GRAPH_VALIDATOR_INGEST_API_URL", Defaults['INGEST_API']),
+    'INGEST_THROTTLE_PERIOD': float(os.environ.get("INGEST_GRAPH_VALIDATOR_INGEST_THROTTLE_PERIOD", Defaults['INGEST_THROTTLE_PERIOD'])),
     'GOOGLE_APPLICATION_CREDENTIALS': os.environ.get("INGEST_GRAPH_VALIDATOR_GOOGLE_APPLICATION_CREDENTIALS", Defaults['GOOGLE_APPLICATION_CREDENTIALS']),
     'INGEST_JWT_AUDIENCE': os.environ.get("INGEST_GRAPH_VALIDATOR_INGEST_JWT_AUDIENCE", Defaults["INGEST_JWT_AUDIENCE"]),
     'NEO4J_IMAGE': "neo4j:3.5.14-enterprise",
@@ -37,6 +40,7 @@ Config = {
     'AMQP_EXCHANGE_NAME': os.environ.get("AMQP_EXCHANGE_NAME", Defaults['AMQP_EXCHANGE_NAME']),
     'AMQP_QUEUE_NAME': os.environ.get("AMQP_QUEUE_NAME", Defaults['AMQP_QUEUE_NAME']),
     'AMQP_ROUTING_KEY': os.environ.get("AMQP_ROUTING_KEY", Defaults['AMQP_ROUTING_KEY']),
+    'NEO4J_IMPORT_BATCH_SIZE': os.environ.get("INGEST_GRAPH_VALIDATOR_NEO4J_IMPORT_BATCH_SIZE", Defaults['NEO4J_IMPORT_BATCH_SIZE']),
 }
 
 

--- a/ingest_graph_validator/hydrators/hydrator.py
+++ b/ingest_graph_validator/hydrators/hydrator.py
@@ -2,13 +2,17 @@
 
 import logging
 
+from py2neo import Graph, Node
+
+from ingest_graph_validator.config import Config
+
 
 class Hydrator:
     """
     Hydrator main class, any hydrators implemented for the graph validator must implement this interface.
     """
 
-    def __init__(self, graph):
+    def __init__(self, graph:Graph):
         self._logger = logging.getLogger(__name__)
         self._graph = graph
 
@@ -17,6 +21,8 @@ class Hydrator:
 
         self._edges = []
         """Edge list of py4neo Relationship objects."""
+
+        self.batch_size = Config['NEO4J_IMPORT_BATCH_SIZE']
 
     def hydrate(self):
         """
@@ -32,15 +38,25 @@ class Hydrator:
     def fill_nodes(self, graph, nodes):
         tx = self._graph.begin()
 
-        for node in list(nodes.values()):
+        self._logger.info('filling nodes')
+        node: Node
+        for i, node in enumerate(nodes.values()):
+            tx = self.maybe_commit_tx(i, tx)
             tx.create(node)
-
         tx.commit()
+
+    def maybe_commit_tx(self, i, tx):
+        if i % self.batch_size == 0:
+            self._logger.info(f'maybe_commit_tx: completed {i} items')
+            tx.commit()
+            tx = self._graph.begin()
+        return tx
 
     def fill_edges(self, graph, edges):
         tx = self._graph.begin()
-
-        for edge in edges:
+        self._logger.info('filling edges')
+        for i, edge in enumerate(list(edges)):
+            tx = self.maybe_commit_tx(i, tx)
             tx.create(edge)
 
         tx.commit()

--- a/ingest_graph_validator/ingest_graph_validator.py
+++ b/ingest_graph_validator/ingest_graph_validator.py
@@ -72,16 +72,17 @@ def entry_point(ctx, log_level, db_url, bolt_port, frontend_port):
     while True:
         try:
             logger.info("Connecting to neo4j...")
-            retries+=1
+            retries += 1
             ctx.obj.graph = Graph(f"{Config['NEO4J_DB_URL']}:{Config['NEO4J_BOLT_PORT']}", user=Config['NEO4J_DB_USERNAME'],
                                 password=Config['NEO4J_DB_PASSWORD'])
             break
-            
+
         except errors.ConnectionUnavailable:
-            logger.info("Couldn't connect to neo4j, retrying...")
-            if retries >= 10:
-                raise Exception("Tried to connect to neo4j more than 10 times. Exiting")
-            
+            max_retries = 10
+            logger.info(f"Couldn't connect to neo4j, retrying ({retries}/{max_retries})...")
+            if retries >= max_retries:
+                raise Exception(f'Tried to connect to neo4j more than {max_retries} times. Exiting')
+
             time.sleep(5)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ et-xmlfile~=1.0.1
     # via
     #   ingest-graph-validator (setup.py)
     #   openpyxl
+hca_ingest
 idna~=2.10
     # via
     #   ingest-graph-validator (setup.py)


### PR DESCRIPTION
optimise handling of big datasets:
- batch commit to neo4j
- no need to maintain entities in a dict with uuids as keys. It is a waste of memory and costs a lot during entry and extraction. A simple list is enough.

Adding informative logging messages every 1000 records. This could be deleted when the problem is solved.

This improves generating the nodes list and loading to neo.
The edges generation is still not scaling well. It starts fast, but there is degradation after a few thousand edges. Running locally is impractical due to this. Installation on dev is required to check whether the current optimisations are enough at this point.



dcp-925
ebi-ait/dcp-ingest-central#925